### PR TITLE
Some semantic changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1114,7 +1114,7 @@ dependencies = [
  "serde_bytes",
  "spin_sleep",
  "spin_sleep_util",
- "syn 2.0.52",
+ "syn 1.0.109",
  "tobj",
  "unique_64",
  "wgpu",
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -1782,9 +1782,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/src/file_utilities.rs
+++ b/src/file_utilities.rs
@@ -9,7 +9,7 @@ use std::{
 /// Simply check if a directory exists.
 ///
 pub fn dir_exists(path: &str) -> bool {
-  Path::new(path).exists()
+  Path::new(path).is_dir()
 }
 
 ///
@@ -18,7 +18,7 @@ pub fn dir_exists(path: &str) -> bool {
 /// a file.
 ///
 pub fn file_exists(path: &str) -> bool {
-  Path::new(path).exists()
+  Path::new(path).is_file()
 }
 
 ///

--- a/src/game/client/window_handler/key_event_enum.rs
+++ b/src/game/client/window_handler/key_event_enum.rs
@@ -16,16 +16,10 @@ pub enum KeyEvent {
 
 impl KeyEvent {
   pub fn is_up(&self) -> bool {
-    match self {
-      KeyEvent::PressingDown => false,
-      KeyEvent::LiftedOff => true,
-    }
+    matches!(self, KeyEvent::LiftedOff)
   }
 
   pub fn is_down(&self) -> bool {
-    match self {
-      KeyEvent::PressingDown => true,
-      KeyEvent::LiftedOff => false,
-    }
+    matches!(self, KeyEvent::PressingDown)
   }
 }


### PR DESCRIPTION
Conglomerated server and client, along with their flags, into an enum called `ServerClient`, that handles either, and is actually exclusive.
- [ ] Make better name for `ServerClient`

Replaced vsync sentinel values with `VSyncMode` enum.
`Path.is_dir` and `Path.is_file` return false if the path is broken, so they can be used instead, and actually do what they are named.
`match` changed to `matches!` for ease of reading.